### PR TITLE
squashfs: implement squashfs mount structure and necessary subroutine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ _.arm64.*
 _.i386.*
 _.powerpc.*
 _.riscv.*
+.DS_STORE
 GPATH
 GRTAGS
 GTAGS

--- a/sys/fs/squashfs/Makefile
+++ b/sys/fs/squashfs/Makefile
@@ -1,0 +1,8 @@
+KMOD=	squashfs
+SRCS=	\
+	squashfs_block.c \
+	squashfs_io.c
+
+SRCS+=	vnode_if.h
+
+.include <bsd.kmod.mk>

--- a/sys/fs/squashfs/squashfs.h
+++ b/sys/fs/squashfs/squashfs.h
@@ -1,0 +1,314 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2023 Raghav Sharma <raghav@freebsd.org>
+ * Parts Copyright (c) 2014 Dave Vasilevsky <dave@vasilevsky.ca>
+ * Obtained from the squashfuse project
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#ifndef	SQUASHFS_H
+#define	SQUASHFS_H
+
+#define	SQUASHFS_MAGIC				0x73717368
+#define	SQUASHFS_MAGIC_SWAP 		0x68737173
+
+#define	SQUASHFS_CACHED_FRAGMENTS	3
+#define	SQUASHFS_MAJOR				4
+#define	SQUASHFS_MINOR				0
+#define	SQUASHFS_START				0
+
+#define	SQUASHFS_METADATA_SIZE		8192
+#define	SQUASHFS_METADATA_LOG		13
+
+#define	SQUASHFS_FILE_SIZE			131072
+#define	SQUASHFS_FILE_LOG			17
+
+#define	SQUASHFS_FILE_MAX_SIZE		1048576
+#define	SQUASHFS_FILE_MAX_LOG		20
+
+#define	SQUASHFS_IDS				65536
+
+#define	SQUASHFS_MAX_NAME_LEN		256
+
+#define	SQUASHFS_INVALID_FRAG		(0xffffffffU)
+#define	SQUASHFS_INVALID_XATTR		(0xffffffffU)
+#define	SQUASHFS_INVALID_BLK		((int64_t)-1)
+
+#define	SQUASHFS_IO_SIZE			65536
+
+/* Filesystem flags */
+#define	SQUASHFS_NOI				0
+#define	SQUASHFS_NOD				1
+#define	SQUASHFS_NOF				3
+#define	SQUASHFS_NO_FRAG			4
+#define	SQUASHFS_ALWAYS_FRAG		5
+#define	SQUASHFS_DUPLICATE			6
+#define	SQUASHFS_EXPORT				7
+#define	SQUASHFS_COMP_OPT			10
+
+/* Max number of types and file types */
+#define	SQUASHFS_DIR_TYPE			1
+#define	SQUASHFS_REG_TYPE			2
+#define	SQUASHFS_SYMLINK_TYPE		3
+#define	SQUASHFS_BLKDEV_TYPE		4
+#define	SQUASHFS_CHRDEV_TYPE		5
+#define	SQUASHFS_FIFO_TYPE			6
+#define	SQUASHFS_SOCKET_TYPE		7
+#define	SQUASHFS_LDIR_TYPE			8
+#define	SQUASHFS_LREG_TYPE			9
+#define	SQUASHFS_LSYMLINK_TYPE		10
+#define	SQUASHFS_LBLKDEV_TYPE		11
+#define	SQUASHFS_LCHRDEV_TYPE		12
+#define	SQUASHFS_LFIFO_TYPE			13
+#define	SQUASHFS_LSOCKET_TYPE		14
+
+#define	SQUASHFS_COMPRESSED_BIT		(1 << 15)
+#define	SQUASHFS_COMPRESSED_BIT_BLOCK	(1 << 24)
+
+/* cached data constants for filesystem */
+#define	SQUASHFS_CACHED_BLKS		8
+
+#define	SQUASHFS_MAX_FILE_SIZE_LOG	64
+
+#define	SQUASHFS_MAX_FILE_SIZE		(1LL << \
+					(SQUASHFS_MAX_FILE_SIZE_LOG - 2))
+
+/* meta index cache */
+#define	SQUASHFS_META_INDEXES		(SQUASHFS_METADATA_SIZE / sizeof(unsigned int))
+#define	SQUASHFS_META_ENTRIES		127
+#define	SQUASHFS_META_SLOTS			8
+
+/* definitions for structures on disk */
+#define	ZLIB_COMPRESSION	1
+#define	LZMA_COMPRESSION	2
+#define	LZO_COMPRESSION		3
+#define	XZ_COMPRESSION		4
+#define	LZ4_COMPRESSION		5
+#define	ZSTD_COMPRESSION	6
+
+struct sqsh_sb {
+	uint32_t		s_magic;
+	uint32_t		inodes;
+	uint32_t		mkfs_time;
+	uint32_t		block_size;
+	uint32_t		fragments;
+	uint16_t		compression;
+	uint16_t		block_log;
+	uint16_t		flags;
+	uint16_t		no_ids;
+	uint16_t		s_major;
+	uint16_t		s_minor;
+	uint64_t		root_inode;
+	uint64_t		bytes_used;
+	uint64_t		id_table_start;
+	uint64_t		xattr_id_table_start;
+	uint64_t		inode_table_start;
+	uint64_t		directory_table_start;
+	uint64_t		fragment_table_start;
+	uint64_t		lookup_table_start;
+};
+
+struct sqsh_dir_index {
+	uint32_t		index;
+	uint32_t		start_block;
+	uint32_t		size;
+};
+
+struct sqsh_base_inode {
+	uint16_t		inode_type;
+	uint16_t		mode;
+	uint16_t		uid;
+	uint16_t		guid;
+	uint32_t		mtime;
+	uint32_t		inode_number;
+};
+
+struct sqsh_ipc_inode {
+	uint16_t		inode_type;
+	uint16_t		mode;
+	uint16_t		uid;
+	uint16_t		guid;
+	uint32_t		mtime;
+	uint32_t		inode_number;
+	uint32_t		nlink;
+};
+
+struct sqsh_lipc_inode {
+	uint16_t		inode_type;
+	uint16_t		mode;
+	uint16_t		uid;
+	uint16_t		guid;
+	uint32_t		mtime;
+	uint32_t		inode_number;
+	uint32_t		nlink;
+	uint32_t		xattr;
+};
+
+struct sqsh_dev_inode {
+	uint16_t		inode_type;
+	uint16_t		mode;
+	uint16_t		uid;
+	uint16_t		guid;
+	uint32_t		mtime;
+	uint32_t		inode_number;
+	uint32_t		nlink;
+	uint32_t		rdev;
+};
+
+struct sqsh_ldev_inode {
+	uint16_t		inode_type;
+	uint16_t		mode;
+	uint16_t		uid;
+	uint16_t		guid;
+	uint32_t		mtime;
+	uint32_t		inode_number;
+	uint32_t		nlink;
+	uint32_t		rdev;
+	uint32_t		xattr;
+};
+
+struct sqsh_symlink_inode {
+	uint16_t		inode_type;
+	uint16_t		mode;
+	uint16_t		uid;
+	uint16_t		guid;
+	uint32_t		mtime;
+	uint32_t		inode_number;
+	uint32_t		nlink;
+	uint32_t		symlink_size;
+};
+
+struct sqsh_reg_inode {
+	uint16_t		inode_type;
+	uint16_t		mode;
+	uint16_t		uid;
+	uint16_t		guid;
+	uint32_t		mtime;
+	uint32_t		inode_number;
+	uint32_t		start_block;
+	uint32_t		fragment;
+	uint32_t		offset;
+	uint32_t		file_size;
+};
+
+struct sqsh_lreg_inode {
+	uint16_t		inode_type;
+	uint16_t		mode;
+	uint16_t		uid;
+	uint16_t		guid;
+	uint32_t		mtime;
+	uint32_t		inode_number;
+	uint64_t		start_block;
+	uint64_t		file_size;
+	uint64_t		sparse;
+	uint32_t		nlink;
+	uint32_t		fragment;
+	uint32_t		offset;
+	uint32_t		xattr;
+};
+
+struct sqsh_dir_inode {
+	uint16_t		inode_type;
+	uint16_t		mode;
+	uint16_t		uid;
+	uint16_t		guid;
+	uint32_t		mtime;
+	uint32_t		inode_number;
+	uint32_t		start_block;
+	uint32_t		nlink;
+	uint16_t		file_size;
+	uint16_t		offset;
+	uint32_t		parent_inode;
+};
+
+struct sqsh_ldir_inode {
+	uint16_t		inode_type;
+	uint16_t		mode;
+	uint16_t		uid;
+	uint16_t		guid;
+	uint32_t		mtime;
+	uint32_t		inode_number;
+	uint32_t		nlink;
+	uint32_t		file_size;
+	uint32_t		start_block;
+	uint32_t		parent_inode;
+	uint16_t		i_count;
+	uint16_t		offset;
+	uint32_t		xattr;
+};
+
+struct sqsh_dir_entry {
+	uint16_t		offset;
+	uint16_t		inode_number;
+	uint16_t		type;
+	uint16_t		size;
+};
+
+struct sqsh_dir_header {
+	uint32_t		count;
+	uint32_t		start_block;
+	uint32_t		inode_number;
+};
+
+struct sqsh_fragment_entry {
+	uint64_t		start_block;
+	uint32_t		size;
+	uint32_t		unused;
+};
+
+/* This struct handles tables which contains inodes, inode ID and fragments */
+struct sqsh_table {
+	size_t		each;
+	uint64_t	*blocks;
+};
+
+/* This overlays the fid structure (see mount.h) */
+struct sqsh_fid {
+	uint16_t	len;
+	uint16_t	pad;
+	ino_t		ino;
+	uint32_t	gen;
+};
+
+extern struct vop_vector squashfs_vnodeops;
+
+#define	SQUASHFS_DEBUG
+#ifdef	SQUASHFS_DEBUG
+#define	TRACE(x...)	printf("\n\033[0;34msquashfs:\33[0m " x)
+#else	/* !SQUASHFS_DEBUG */
+#define	TRACE(x...)
+#endif	/* SQUASHFS_DEBUG */
+#define	ERROR(x...)	printf("\n\033[0;31msquashfs:\33[0m " x)
+
+typedef enum {
+	SQFS_OK,			/* everything fine */
+	SQFS_BADFORMAT,		/* unsupported file format */
+	SQFS_BADVERSION,	/* unsupported squashfs version */
+	SQFS_BADCOMP,		/* unsupported compression method */
+	SQFS_UNSUP,			/* unsupported feature */
+	SQFS_ERR			/* error in operation */
+} sqsh_err;
+
+#endif	/* SQUASHFS_H */

--- a/sys/fs/squashfs/squashfs_block.c
+++ b/sys/fs/squashfs/squashfs_block.c
@@ -1,0 +1,223 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2023 Raghav Sharma <raghav@freebsd.org>
+ * Parts Copyright (c) 2014 Dave Vasilevsky <dave@vasilevsky.ca>
+ * Obtained from the squashfuse project
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/buf.h>
+#include <sys/conf.h>
+#include <sys/fcntl.h>
+#include <sys/libkern.h>
+#include <sys/limits.h>
+#include <sys/lock.h>
+#include <sys/malloc.h>
+#include <sys/mount.h>
+#include <sys/mutex.h>
+#include <sys/namei.h>
+#include <sys/priv.h>
+#include <sys/proc.h>
+#include <sys/queue.h>
+#include <sys/sbuf.h>
+#include <sys/stat.h>
+#include <sys/uio.h>
+#include <sys/vnode.h>
+
+#include <squashfs.h>
+#include <squashfs_io.h>
+#include <squashfs_mount.h>
+#include <squashfs_block.h>
+
+static	MALLOC_DEFINE(M_SQUASHFSBLOCK, "SQUASHFS block", "SQUASHFS block structure");
+static	MALLOC_DEFINE(M_SQUASHFSBLOCKD, "SQUASHFS block data", "SQUASHFS block data buffer");
+
+void
+sqsh_metadata_header(uint16_t hdr, bool *compressed, uint16_t *size)
+{
+    /* Bit is set if block is uncompressed */
+    *compressed = !(hdr & SQUASHFS_COMPRESSED_BIT);
+    *size = hdr & ~SQUASHFS_COMPRESSED_BIT;
+    if (!*size)
+        *size = SQUASHFS_COMPRESSED_BIT;
+}
+
+void
+sqsh_data_header(uint32_t hdr, bool *compressed, uint32_t *size)
+{
+    *compressed = !(hdr & SQUASHFS_COMPRESSED_BIT_BLOCK);
+    *size = hdr & ~SQUASHFS_COMPRESSED_BIT_BLOCK;
+}
+
+sqsh_err
+sqsh_block_read(struct sqsh_mount *ump, off_t pos, bool compressed,
+    uint32_t size, size_t outsize, struct sqsh_block **block)
+{
+	sqsh_err err;
+    /* allocate block on heap */
+    *block = malloc(sizeof(**block), M_SQUASHFSBLOCK, M_WAITOK);
+	if (*block == NULL)
+		return (SQFS_ERR);
+    (*block)->data = malloc(size, M_SQUASHFSBLOCKD, M_WAITOK);
+	if ((*block)->data == NULL)
+		goto error;
+
+    if (sqsh_io_read_buf(ump, (*block)->data, pos, size) != size) {
+		ERROR("Failed to read data, I/O error");
+		goto error;
+	}
+
+    /* if block is compressed, first decompressed it and then initialize block */
+	if (compressed) {
+		char *decomp = malloc(outsize, M_SQUASHFSBLOCKD, M_WAITOK);
+		if (decomp == NULL)
+			goto error;
+
+		err = ump->decompressor->decompressor((*block)->data, size, decomp, &outsize);
+		if (err != SQFS_OK) {
+			free(decomp, M_SQUASHFSBLOCKD);
+			goto error;
+		}
+		free((*block)->data, M_SQUASHFSBLOCKD);
+		(*block)->data = decomp;
+		(*block)->size = outsize;
+	} else {
+		(*block)->size = size;
+	}
+
+	return (SQFS_OK);
+
+error:
+	sqsh_free_block(*block);
+	*block = NULL;
+	return (SQFS_ERR);
+}
+
+void
+sqsh_free_block(struct sqsh_block *block)
+{
+	free(block->data, M_SQUASHFSBLOCKD);
+	free(block, M_SQUASHFSBLOCK);
+}
+
+sqsh_err
+sqsh_metadata_read(struct sqsh_mount *ump, off_t pos, size_t *data_size,
+	struct sqsh_block **block)
+{
+	uint16_t hdr;
+	bool compressed;
+	uint16_t size;
+	sqsh_err err;
+
+	*data_size = 0;
+
+	if (sqsh_io_read_buf(ump, &hdr, pos, sizeof(hdr)) != sizeof(hdr)) {
+		ERROR("Failed to read data, I/O error");
+		return (SQFS_ERR);
+	}
+
+	pos += sizeof(hdr);
+	*data_size += sizeof(hdr);
+	hdr = le16toh(hdr);
+
+	sqsh_metadata_header(hdr, &compressed, &size);
+
+	err = sqsh_block_read(ump, pos, compressed, size,
+		SQUASHFS_METADATA_SIZE, block);
+	*data_size += size;
+
+	return (err);
+}
+
+sqsh_err
+sqsh_data_read(struct sqsh_mount *ump, off_t pos,
+	uint32_t hdr, struct sqsh_block **block)
+{
+	bool compressed;
+	uint32_t size;
+	sqsh_err err;
+
+	sqsh_data_header(hdr, &compressed, &size);
+	err = sqsh_block_read(ump, pos, compressed, size,
+		ump->sb.block_size, block);
+
+	return (err);
+}
+
+sqsh_err
+sqsh_metadata_get(struct sqsh_mount *ump, struct sqsh_block_run
+	*cur, void *buf, size_t size)
+{
+	off_t pos;
+
+	pos = cur->block;
+	while (size > 0) {
+		struct sqsh_block *block;
+		size_t take;
+		size_t data_size;
+		sqsh_err err;
+
+		data_size = 0;
+		err = sqsh_metadata_read(ump, pos, &data_size, &block);
+		if (err != SQFS_OK)
+			return (err);
+
+		pos += data_size;
+
+		take = block->size - cur->offset;
+		if (take > size)
+			take = size;
+		if (buf)
+			memcpy(buf, (char*)block->data + cur->offset, take);
+
+		if (buf)
+			buf = (char*)buf + take;
+		size -= take;
+		cur->offset += take;
+		if (cur->offset == block->size) {
+			cur->block = pos;
+			cur->offset = 0;
+		}
+
+		/* Free block since currently we have no cache */
+		sqsh_free_block(block);
+	}
+	return (SQFS_OK);
+}
+
+/* This is a normal ceil function */
+size_t
+sqsh_ceil(uint64_t total, size_t group)
+{
+	size_t ans;
+
+	ans = (size_t)(total / group);
+	if (total % group)
+		ans += 1;
+
+	return (ans);
+}

--- a/sys/fs/squashfs/squashfs_block.h
+++ b/sys/fs/squashfs/squashfs_block.h
@@ -1,0 +1,63 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2023 Raghav Sharma <raghav@freebsd.org>
+ * Parts Copyright (c) 2014 Dave Vasilevsky <dave@vasilevsky.ca>
+ * Obtained from the squashfuse project
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#ifndef	SQUASHFS_BLOCK_H
+#define	SQUASHFS_BLOCK_H
+
+struct sqsh_block {
+	size_t	size;
+	void*	data;
+};
+
+struct sqsh_block_run {
+	off_t	block;
+	size_t	offset;
+};
+
+/* Helper functions to check if metadata/data block is compressed and its size */
+void		sqsh_metadata_header(uint16_t hdr, bool *compressed, uint16_t *size);
+void		sqsh_data_header(uint32_t hdr, bool *compressed, uint32_t *size);
+
+sqsh_err	sqsh_block_read(struct sqsh_mount *ump, off_t pos, bool compressed,
+				uint32_t size, size_t outsize, struct sqsh_block **block);
+void		sqsh_free_block(struct sqsh_block *block);
+
+sqsh_err	sqsh_metadata_read(struct sqsh_mount *ump, off_t pos, size_t *data_size,
+				struct sqsh_block **block);
+sqsh_err	sqsh_data_read(struct sqsh_mount *ump, off_t pos, uint32_t hdr,
+				struct sqsh_block **block);
+
+sqsh_err	sqsh_metadata_get(struct sqsh_mount *ump, struct sqsh_block_run *cur,
+				void *buf, size_t size);
+
+/* Number of groups of size "group" required to hold size "total" */
+size_t		sqsh_ceil(uint64_t total, size_t group);
+
+#endif

--- a/sys/fs/squashfs/squashfs_io.c
+++ b/sys/fs/squashfs/squashfs_io.c
@@ -1,0 +1,127 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2023 Raghav Sharma <raghav@freebsd.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/buf.h>
+#include <sys/conf.h>
+#include <sys/fcntl.h>
+#include <sys/libkern.h>
+#include <sys/limits.h>
+#include <sys/lock.h>
+#include <sys/malloc.h>
+#include <sys/mount.h>
+#include <sys/mutex.h>
+#include <sys/namei.h>
+#include <sys/priv.h>
+#include <sys/proc.h>
+#include <sys/queue.h>
+#include <sys/sbuf.h>
+#include <sys/stat.h>
+#include <sys/uio.h>
+#include <sys/vnode.h>
+
+#include <squashfs.h>
+#include <squashfs_mount.h>
+#include <squashfs_io.h>
+
+sqsh_err    sqsh_io_read(struct sqsh_mount *ump, struct uio *uiop);
+
+/*
+ * Reads data according to the provided uio.
+ * This function reads directly from disk file
+ * and all decompression reads are handled by seperate
+ * functions in squashfs_block.h file.
+ */
+sqsh_err
+sqsh_io_read(struct sqsh_mount *ump, struct uio *uiop)
+{
+	void *rl;
+	off_t off;
+	size_t len;
+	int error;
+
+	off	= uiop->uio_offset;
+	len	= uiop->uio_resid;
+
+	rl = vn_rangelock_rlock(ump->um_vp, off, off + len);
+	error = vn_lock(ump->um_vp, LK_SHARED);
+	if (error == 0) {
+		error = VOP_READ(ump->um_vp, uiop, IO_DIRECT|IO_NODELOCKED,
+			uiop->uio_td->td_ucred);
+		VOP_UNLOCK(ump->um_vp);
+	}
+	vn_rangelock_unlock(ump->um_vp, rl);
+
+	return ( error != 0 ? SQFS_ERR : SQFS_OK );
+}
+
+/*
+ * Reads data into the provided buffer.
+ * This function reads directly from disk file
+ * and all decompression reads are handled by seperate
+ * functions in squashfs_block.h file.
+ * On succes it return number of bytes read else negative
+ * value on failure.
+ */
+ssize_t
+sqsh_io_read_buf(struct sqsh_mount *ump, void *buf, off_t off, size_t len)
+{
+	struct uio auio;
+	struct iovec aiov;
+	sqsh_err error;
+	ssize_t res;
+
+	/* return success and reading zero bytes of data */
+	if (len == 0)
+		return (0);
+
+	/* initialize iovec */
+	aiov.iov_base	=	buf;
+	aiov.iov_len	=	len;
+
+	/* initialize uio */
+	auio.uio_iov	=	&aiov;
+	auio.uio_iovcnt	=	1;
+	auio.uio_offset	=	off;
+	auio.uio_segflg	=	UIO_SYSSPACE;
+	auio.uio_rw		=	UIO_READ;
+	auio.uio_resid	=	len;
+	auio.uio_td		=	curthread;
+
+	error = sqsh_io_read(ump, &auio);
+
+	/* return negative value on reading failure */
+	if (error != SQFS_OK)
+		return (-1);
+
+	res = len - auio.uio_resid;
+
+	return (res);
+}

--- a/sys/fs/squashfs/squashfs_io.h
+++ b/sys/fs/squashfs/squashfs_io.h
@@ -1,0 +1,37 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2023 Raghav Sharma <raghav@freebsd.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+#ifndef	SQUASHFS_IO
+#define	SQUASHFS_IO
+
+#include <squashfs_mount.h>
+
+ssize_t     sqsh_io_read_buf(struct sqsh_mount *ump, void *buf, off_t off, size_t len);
+
+#endif

--- a/sys/fs/squashfs/squashfs_mount.h
+++ b/sys/fs/squashfs/squashfs_mount.h
@@ -1,0 +1,59 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2023 Raghav Sharma <raghav@freebsd.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+#ifndef	SQUASHFS_MOUNT_H
+#define	SQUASHFS_MOUNT_H
+
+#ifdef	_KERNEL
+
+/* This structure describes squashfs mount structure data */
+struct sqsh_mount {
+	struct mount					*um_mountp;
+	struct vnode					*um_vp;
+	struct sqsh_sb					sb;
+	struct sqsh_table				id_table;
+	struct sqsh_table				frag_table;
+	struct sqsh_table				export_table;
+	const struct sqsh_decompressor	*decompressor;
+};
+
+static inline struct sqsh_mount *
+MP_TO_SQSH_MOUNT(struct mount *mp)
+{
+	MPASS(mp != NULL && mp->mnt_data != NULL);
+	return (mp->mnt_data);
+}
+
+/* Define all accepted compressions */
+#define	SQUASHFS_ZLIB
+
+#endif	/* _KERNEL */
+
+#endif	/* SQUASHFS_MOUNT_H */


### PR DESCRIPTION
The files that need complete review are:
- squashfs_io.c
- squashfs_io.h
- squashfs_mount.h

The files which are from already tested source code of squashfs and modified for FreeBSD are:
- squashfs_block.h
- squashfs_block.c
- squashfs.h

In squashfs.h file there are some DEBUG macros that are implemented by us so it will be up for review.