### PR TITLE
squashfs: Implement squashfs inode structure

### DIFF
--- a/sys/fs/squashfs/Makefile
+++ b/sys/fs/squashfs/Makefile
@@ -2,7 +2,8 @@ KMOD=	squashfs
 SRCS=	\
 	squashfs_block.c \
 	squashfs_io.c \
-	squashfs_decompressor.c
+	squashfs_decompressor.c \
+	squashfs_inode.c
 
 SRCS+=	vnode_if.h
 SRCS+=	opt_gzio.h

--- a/sys/fs/squashfs/squashfs.h
+++ b/sys/fs/squashfs/squashfs.h
@@ -58,6 +58,10 @@
 
 #define	SQUASHFS_IO_SIZE			65536
 
+#define	SQUASHFS_TYPE_MIN_VALID		1
+#define	SQUASHFS_TYPE_MAX_VALID		14
+#define	SQUASHFS_INODE_MIN_COUNT	1
+
 /* Filesystem flags */
 #define	SQUASHFS_NOI				0
 #define	SQUASHFS_NOD				1

--- a/sys/fs/squashfs/squashfs_inode.c
+++ b/sys/fs/squashfs/squashfs_inode.c
@@ -1,0 +1,274 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2023 Raghav Sharma <raghav@freebsd.org>
+ * Parts Copyright (c) 2014 Dave Vasilevsky <dave@vasilevsky.ca>
+ * Obtained from the squashfuse project
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/buf.h>
+#include <sys/conf.h>
+#include <sys/fcntl.h>
+#include <sys/libkern.h>
+#include <sys/limits.h>
+#include <sys/lock.h>
+#include <sys/malloc.h>
+#include <sys/mount.h>
+#include <sys/mutex.h>
+#include <sys/namei.h>
+#include <sys/priv.h>
+#include <sys/proc.h>
+#include <sys/queue.h>
+#include <sys/sbuf.h>
+#include <sys/stat.h>
+#include <sys/uio.h>
+#include <sys/vnode.h>
+
+#include <squashfs.h>
+#include <squashfs_io.h>
+#include <squashfs_mount.h>
+#include <squashfs_block.h>
+#include <squashfs_inode.h>
+#include <squashfs_decompressor.h>
+
+/* Swapendian functions for all types of inodes */
+void		swapendian_base_inode(struct sqsh_base_inode *temp);
+void		swapendian_reg_inode(struct sqsh_reg_inode *temp);
+void		swapendian_lreg_inode(struct sqsh_lreg_inode *temp);
+
+/* init functions for all types of inodes */
+sqsh_err	sqsh_init_reg_inode(struct sqsh_mount *ump, struct sqsh_inode *inode);
+sqsh_err	sqsh_init_lreg_inode(struct sqsh_mount *ump, struct sqsh_inode *inode);
+
+void
+sqsh_metadata_run_inode(struct sqsh_block_run *cur, uint64_t id, off_t base)
+{
+	cur->block = (id >> 16) + base;
+	cur->offset = id & 0xffff;
+}
+
+enum vtype
+sqsh_inode_type(int inode_type)
+{
+	switch (inode_type) {
+	case SQUASHFS_DIR_TYPE:
+	case SQUASHFS_LDIR_TYPE:
+		return (VDIR);
+	case SQUASHFS_REG_TYPE:
+	case SQUASHFS_LREG_TYPE:
+		return (VREG);
+	case SQUASHFS_SYMLINK_TYPE:
+	case SQUASHFS_LSYMLINK_TYPE:
+		return (VLNK);
+	case SQUASHFS_BLKDEV_TYPE:
+	case SQUASHFS_LBLKDEV_TYPE:
+		return (VBLK);
+	case SQUASHFS_CHRDEV_TYPE:
+	case SQUASHFS_LCHRDEV_TYPE:
+		return (VCHR);
+	case SQUASHFS_FIFO_TYPE:
+	case SQUASHFS_LFIFO_TYPE:
+		return (VFIFO);
+	case SQUASHFS_SOCKET_TYPE:
+	case SQUASHFS_LSOCKET_TYPE:
+		return (VSOCK);
+	}
+	return (VBAD);
+}
+
+sqsh_err
+sqsh_verify_inode(struct sqsh_mount *ump, struct sqsh_inode *inode)
+{
+
+	/* check for inode type */
+	if (inode->base.inode_type < SQUASHFS_TYPE_MIN_VALID
+		|| inode->base.inode_type > SQUASHFS_TYPE_MAX_VALID)
+		return (SQFS_ERR);
+
+	/*
+	 * check for inode_number.
+	 * The inode numbers are from 1 to the total number of inodes.
+	 * Note that 0 is always invalid because we will
+	 * always have at least a root inode.
+	 */
+	if (inode->base.inode_number < SQUASHFS_INODE_MIN_COUNT
+		|| inode->base.inode_number > ump->sb.inodes)
+		return (SQFS_ERR);
+
+	/*
+	 * If inode type is directory then check for parent inode.
+	 * Note that we add +1 because for root inode parent_inode
+	 * is total inodes + 1
+	 */
+	if (inode->base.inode_type == SQUASHFS_DIR_TYPE) {
+		if (inode->xtra.dir.parent_inode < SQUASHFS_INODE_MIN_COUNT
+			|| inode->xtra.dir.parent_inode > ump->sb.inodes + 1)
+			return (SQFS_ERR);
+	}
+
+	return (SQFS_OK);
+}
+
+uint64_t
+sqsh_root_inode(struct sqsh_mount *ump)
+{
+	return (ump->sb.root_inode);
+}
+
+sqsh_err
+sqsh_get_inode(struct sqsh_mount *ump, struct sqsh_inode *inode,
+	uint64_t id)
+{
+	struct sqsh_block_run cur;
+	sqsh_err err;
+
+	assert(inode != NULL);
+
+	/* initialise all inode fields to 0 */
+	memset(inode, 0, sizeof(*inode));
+	inode->xattr = SQUASHFS_INVALID_XATTR;
+
+	sqsh_metadata_run_inode(&cur, id, ump->sb.inode_table_start);
+	inode->next = cur;
+
+	err = sqsh_metadata_get(ump, &cur, &inode->base, sizeof(inode->base));
+	if (err != SQFS_OK)
+		return (err);
+	swapendian_base_inode(&inode->base);
+	inode->type = sqsh_inode_type(inode->base.inode_type);
+
+	switch (inode->base.inode_type) {
+	case SQUASHFS_REG_TYPE: {
+		err = sqsh_init_reg_inode(ump, inode);
+		if (err != SQFS_OK)
+			return (err);
+		break;
+	}
+	case SQUASHFS_LREG_TYPE: {
+		err = sqsh_init_lreg_inode(ump, inode);
+		if (err != SQFS_OK)
+			return (err);
+		break;
+	}
+	default:
+		return (SQFS_ERR);
+	}
+
+	err = sqsh_verify_inode(ump, inode);
+
+	return (err);
+}
+
+sqsh_err
+sqsh_init_reg_inode(struct sqsh_mount *ump, struct sqsh_inode *inode)
+{
+	struct sqsh_reg_inode temp;
+	sqsh_err err;
+
+	err = sqsh_metadata_get(ump, &inode->next, &temp, sizeof(temp));
+	if (err != SQFS_OK)
+		return (err);
+	swapendian_reg_inode(&temp);
+
+	/* initialise inode reg fields */
+	inode->nlink				=	1;
+	inode->xtra.reg.start_block	=	temp.start_block;
+	inode->size					=	temp.file_size;
+	inode->xtra.reg.frag_idx	=	temp.fragment;
+	inode->xtra.reg.frag_off	=	temp.offset;
+
+	return (SQFS_OK);
+}
+
+sqsh_err
+sqsh_init_lreg_inode(struct sqsh_mount *ump, struct sqsh_inode *inode)
+{
+	struct sqsh_lreg_inode temp;
+	sqsh_err err;
+
+	err = sqsh_metadata_get(ump, &inode->next, &temp, sizeof(temp));
+	if (err != SQFS_OK)
+		return (err);
+	swapendian_lreg_inode(&temp);
+
+	/* initialise inode lreg fields */
+	inode->nlink				=	temp.nlink;
+	inode->xtra.reg.start_block	=	temp.start_block;
+	inode->size					=	temp.file_size;
+	inode->xtra.reg.frag_idx	=	temp.fragment;
+	inode->xtra.reg.frag_off	=	temp.offset;
+	inode->xattr				=	temp.xattr;
+
+	return (SQFS_OK);
+}
+
+void
+swapendian_base_inode(struct sqsh_base_inode *temp)
+{
+
+	temp->inode_type	=	le16toh(temp->inode_type);
+	temp->mode			=	le16toh(temp->mode);
+	temp->uid			=	le16toh(temp->uid);
+	temp->guid			=	le16toh(temp->guid);
+	temp->mtime			=	le32toh(temp->mtime);
+	temp->inode_number	=	le32toh(temp->inode_number);
+}
+
+void
+swapendian_reg_inode(struct sqsh_reg_inode *temp)
+{
+
+	temp->inode_type	=	le16toh(temp->inode_type);
+	temp->mode			=	le16toh(temp->mode);
+	temp->uid			=	le16toh(temp->uid);
+	temp->guid			=	le16toh(temp->guid);
+	temp->mtime			=	le32toh(temp->mtime);
+	temp->inode_number	=	le32toh(temp->inode_number);
+	temp->start_block	=	le32toh(temp->start_block);
+	temp->fragment		=	le32toh(temp->fragment);
+	temp->offset		=	le32toh(temp->offset);
+	temp->file_size		=	le32toh(temp->file_size);
+}
+
+void
+swapendian_lreg_inode(struct sqsh_lreg_inode *temp)
+{
+
+	temp->inode_type	=	le16toh(temp->inode_type);
+	temp->mode			=	le16toh(temp->mode);
+	temp->uid			=	le16toh(temp->uid);
+	temp->guid			=	le16toh(temp->guid);
+	temp->mtime			=	le32toh(temp->mtime);
+	temp->inode_number	=	le32toh(temp->inode_number);
+	temp->start_block	=	le64toh(temp->start_block);
+	temp->file_size		=	le64toh(temp->file_size);
+	temp->sparse		=	le64toh(temp->sparse);
+	temp->nlink			=	le32toh(temp->nlink);
+	temp->fragment		=	le32toh(temp->fragment);
+	temp->offset		=	le32toh(temp->offset);
+	temp->xattr			=	le32toh(temp->xattr);
+}

--- a/sys/fs/squashfs/squashfs_inode.h
+++ b/sys/fs/squashfs/squashfs_inode.h
@@ -1,0 +1,78 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2023 Raghav Sharma <raghav@freebsd.org>
+ * Parts Copyright (c) 2014 Dave Vasilevsky <dave@vasilevsky.ca>
+ * Obtained from the squashfuse project
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#ifndef	SQUASHFS_INODE_H
+#define	SQUASHFS_INODE_H
+
+#define	SQUASHFS_INODE_OFFSET(A)	((unsigned int) ((A) & 0xffff))
+
+struct sqsh_inode {
+	struct sqsh_base_inode	base;
+	int						nlink;
+	uint32_t				xattr;
+	size_t					size;
+
+	enum vtype				type;
+
+	struct sqsh_block_run	next;
+
+	union {
+		struct {
+			int				major;
+			int				minor;
+		} dev;
+		struct {
+			uint64_t		start_block;
+			uint32_t		frag_idx;
+			uint32_t		frag_off;
+		} reg;
+		struct {
+			uint32_t		start_block;
+			uint16_t		offset;
+			uint16_t		idx_count;
+			uint32_t		parent_inode;
+		} dir;
+	} xtra;
+
+	struct vnode			*vnode;
+};
+
+/* helper functions to query on inode */
+void		sqsh_metadata_run_inode(struct sqsh_block_run *cur, uint64_t id,
+				off_t base);
+sqsh_err	sqsh_get_inode(struct sqsh_mount *ump, struct sqsh_inode *inode,
+				uint64_t id);
+
+enum vtype	sqsh_inode_type(int inode_type);
+
+uint64_t	sqsh_root_inode(struct sqsh_mount *ump);
+sqsh_err	sqsh_verify_inode(struct sqsh_mount *ump, struct sqsh_inode *inode);
+
+#endif


### PR DESCRIPTION
This PR adds the following functionalities:

- Implementing the squashfs inode structure.
- Adding support for regular files inode.
- Adding support for large regular files inode.
- A base inode verifier function.
- SwapEndian() to swap the endianness of inode data to the host.

The function sqsh_metadata_run_inode() is taken from squash-fuse implementation which gets block and offset of inode metadata.

Every other function is implemented by me and needs review.